### PR TITLE
Connected the publish profile to azure dependencies.

### DIFF
--- a/CoachingAPI/Program.cs
+++ b/CoachingAPI/Program.cs
@@ -9,30 +9,14 @@ namespace CoachingAPI
         {
             var builder = WebApplication.CreateBuilder(args);
 
-            // Add services to the container.
-            string? connectionString;
-
-            if (builder.Environment.IsDevelopment())
-            {
-                builder.Configuration.AddEnvironmentVariables().AddJsonFile("appsettings.Development.json");
-
-                // Use this if we actually take the connectionstring value from a config file, and not our secretly secret secrets!
-                //connectionString = builder.Configuration.GetConnectionString("AZURE_SQL_CONNECTIONSTRING")
-                //    ?? throw new InvalidOperationException("User secret 'AZURE_SQL_CONNECTIONSTRING' not found.");
-
-                connectionString = builder.Configuration["AZURE_SQL_CONNECTIONSTRING"]
-                    ?? throw new InvalidOperationException("User secret 'AZURE_SQL_CONNECTIONSTRING' not found.");
-            }
-            else
-            {
-                connectionString = Environment.GetEnvironmentVariable("AZURE_SQL_CONNECTIONSTRING")
-                    ?? throw new InvalidOperationException("Connection string 'AZURE_SQL_CONNECTIONSTRING' not found.");
-            }
+            // Fetch connection string from either *top secret* location.
+            string? connectionString = builder.Configuration.GetConnectionString("AZURE_SQL_CONNECTIONSTRING")
+                ?? throw new InvalidOperationException("Connection string 'AZURE_SQL_CONNECTIONSTRING' not found.");
 
             builder.Services.AddDbContext<PlayersDbContext>(options => options.UseSqlServer(connectionString));
-            
+
             builder.Services.AddControllers();
-            // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+
             builder.Services.AddEndpointsApiExplorer();
             builder.Services.AddSwaggerGen();
 
@@ -43,6 +27,7 @@ namespace CoachingAPI
                 app.UseSwaggerUI();
             }
 
+            // Serialize as V2 to comply with Azure App Service.
             app.UseSwagger(options => options.SerializeAsV2 = true);
 
             app.UseHttpsRedirection();

--- a/CoachingAPI/Properties/PublishProfiles/temp-4sem-appservice - Web Deploy.pubxml
+++ b/CoachingAPI/Properties/PublishProfiles/temp-4sem-appservice - Web Deploy.pubxml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
 This file is used by the publish/package process of your Web project. You can customize the behavior of this process
 by editing this MSBuild file. In order to learn more about this please visit https://go.microsoft.com/fwlink/?LinkID=208121. 
@@ -26,5 +26,8 @@ by editing this MSBuild file. In order to learn more about this please visit htt
     <_SavePWD>true</_SavePWD>
     <_DestinationType>AzureWebSite</_DestinationType>
     <InstallAspNetCoreSiteExtension>false</InstallAspNetCoreSiteExtension>
+    <ApiResourceId>/subscriptions/93b405c2-f593-488b-906b-f3e35e89aa93/resourceGroups/temp-4sem-resourcegroup/providers/Microsoft.ApiManagement/service/temp-4sem-apim/apis/CoachingAPI</ApiResourceId>
+    <OpenApiDocumentName>v1</OpenApiDocumentName>
+    <UpdateApiOnPublish>true</UpdateApiOnPublish>
   </PropertyGroup>
 </Project>

--- a/CoachingAPI/Properties/ServiceDependencies/temp-4sem-appservice - Web Deploy/apis1.arm.json
+++ b/CoachingAPI/Properties/ServiceDependencies/temp-4sem-appservice - Web Deploy/apis1.arm.json
@@ -1,0 +1,132 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "resourceGroupName": {
+      "type": "string",
+      "defaultValue": "temp-4sem-resourcegroup",
+      "metadata": {
+        "_parameterType": "resourceGroup",
+        "description": "Name of the resource group for the resource. It is recommended to put resources under same resource group for better tracking."
+      }
+    },
+    "resourceGroupLocation": {
+      "type": "string",
+      "defaultValue": "northeurope",
+      "metadata": {
+        "_parameterType": "location",
+        "description": "Location of the resource group. Resource groups could have different location than resources."
+      }
+    },
+    "resourceLocation": {
+      "type": "string",
+      "defaultValue": "[parameters('resourceGroupLocation')]",
+      "metadata": {
+        "_parameterType": "location",
+        "description": "Location of the resource. By default use resource group's location, unless the resource provider is not supported there."
+      }
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Resources/resourceGroups",
+      "name": "[parameters('resourceGroupName')]",
+      "location": "[parameters('resourceGroupLocation')]",
+      "apiVersion": "2019-10-01"
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "name": "[concat(parameters('resourceGroupName'), 'Deployment', uniqueString(concat('CoachingAPI', subscription().subscriptionId)))]",
+      "resourceGroup": "[parameters('resourceGroupName')]",
+      "apiVersion": "2019-10-01",
+      "dependsOn": [
+        "[parameters('resourceGroupName')]"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "resources": [
+            {
+              "name": "temp-4sem-apim",
+              "type": "Microsoft.ApiManagement/service",
+              "location": "[parameters('resourceLocation')]",
+              "properties": {
+                "publisherEmail": "Kaspernissen1997@outlook.com",
+                "publisherName": "Kasper Nissen",
+                "notificationSenderEmail": "apimgmt-noreply@mail.windowsazure.com",
+                "hostnameConfigurations": [
+                  {
+                    "type": "Proxy",
+                    "hostName": "temp-4sem-apim.azure-api.net",
+                    "encodedCertificate": null,
+                    "keyVaultId": null,
+                    "certificatePassword": null,
+                    "negotiateClientCertificate": false,
+                    "certificate": null,
+                    "defaultSslBinding": true
+                  }
+                ],
+                "publicIPAddresses": null,
+                "privateIPAddresses": null,
+                "additionalLocations": null,
+                "virtualNetworkConfiguration": null,
+                "customProperties": {
+                  "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls10": "False",
+                  "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls11": "False",
+                  "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Backend.Protocols.Tls10": "False",
+                  "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Backend.Protocols.Tls11": "False",
+                  "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Backend.Protocols.Ssl30": "False",
+                  "Microsoft.WindowsAzure.ApiManagement.Gateway.Protocols.Server.Http2": "False"
+                },
+                "virtualNetworkType": "None",
+                "certificates": null,
+                "disableGateway": false,
+                "apiVersionConstraint": {
+                  "minApiVersion": null
+                }
+              },
+              "sku": {
+                "name": "Consumption",
+                "capacity": 0
+              },
+              "apiVersion": "2019-12-01"
+            },
+            {
+              "type": "Microsoft.ApiManagement/service/apis",
+              "name": "temp-4sem-apim/CoachingAPI",
+              "properties": {
+                "displayName": "CoachingAPI",
+                "apiRevision": "1",
+                "description": null,
+                "subscriptionRequired": true,
+                "serviceUrl": null,
+                "path": "",
+                "protocols": [
+                  "https"
+                ],
+                "authenticationSettings": {
+                  "oAuth2": null,
+                  "openid": null
+                },
+                "subscriptionKeyParameterNames": {
+                  "header": "Ocp-Apim-Subscription-Key",
+                  "query": "subscription-key"
+                },
+                "isCurrent": true
+              },
+              "apiVersion": "2019-12-01",
+              "dependsOn": [
+                "temp-4sem-apim"
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "metadata": {
+    "_dependencyType": "apis.azure"
+  }
+}

--- a/CoachingAPI/Properties/ServiceDependencies/temp-4sem-appservice - Web Deploy/mssql1.arm.json
+++ b/CoachingAPI/Properties/ServiceDependencies/temp-4sem-appservice - Web Deploy/mssql1.arm.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "resourceGroupName": {
+      "type": "string",
+      "defaultValue": "temp-4sem-resourcegroup",
+      "metadata": {
+        "_parameterType": "resourceGroup",
+        "description": "Name of the resource group for the resource. It is recommended to put resources under same resource group for better tracking."
+      }
+    },
+    "resourceGroupLocation": {
+      "type": "string",
+      "defaultValue": "northeurope",
+      "metadata": {
+        "_parameterType": "location",
+        "description": "Location of the resource group. Resource groups could have different location than resources."
+      }
+    },
+    "resourceLocation": {
+      "type": "string",
+      "defaultValue": "[parameters('resourceGroupLocation')]",
+      "metadata": {
+        "_parameterType": "location",
+        "description": "Location of the resource. By default use resource group's location, unless the resource provider is not supported there."
+      }
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Resources/resourceGroups",
+      "name": "[parameters('resourceGroupName')]",
+      "location": "[parameters('resourceGroupLocation')]",
+      "apiVersion": "2019-10-01"
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "name": "[concat(parameters('resourceGroupName'), 'Deployment', uniqueString(concat('temp-4sem-sqldb', subscription().subscriptionId)))]",
+      "resourceGroup": "[parameters('resourceGroupName')]",
+      "apiVersion": "2019-10-01",
+      "dependsOn": [
+        "[parameters('resourceGroupName')]"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "resources": [
+            {
+              "kind": "v12.0",
+              "location": "[parameters('resourceLocation')]",
+              "name": "temp-4sem-sqlserver",
+              "type": "Microsoft.Sql/servers",
+              "apiVersion": "2017-10-01-preview"
+            },
+            {
+              "sku": {
+                "name": "GP_S_Gen5",
+                "tier": "GeneralPurpose",
+                "family": "Gen5",
+                "capacity": 2
+              },
+              "kind": "v12.0,user,vcore,serverless,freelimit",
+              "location": "[parameters('resourceLocation')]",
+              "name": "temp-4sem-sqlserver/temp-4sem-sqldb",
+              "type": "Microsoft.Sql/servers/databases",
+              "apiVersion": "2017-10-01-preview",
+              "dependsOn": [
+                "temp-4sem-sqlserver"
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "metadata": {
+    "_dependencyType": "mssql.azure"
+  }
+}

--- a/CoachingAPI/Properties/serviceDependencies.json
+++ b/CoachingAPI/Properties/serviceDependencies.json
@@ -1,0 +1,11 @@
+{
+  "dependencies": {
+    "apis1": {
+      "type": "apis"
+    },
+    "mssql1": {
+      "type": "mssql",
+      "connectionId": "AZURE_SQL_CONNECTIONSTRING"
+    }
+  }
+}

--- a/CoachingAPI/Properties/serviceDependencies.temp-4sem-appservice - Web Deploy.json
+++ b/CoachingAPI/Properties/serviceDependencies.temp-4sem-appservice - Web Deploy.json
@@ -1,8 +1,16 @@
 {
   "dependencies": {
+    "apis1": {
+      "apiEndpoint": "https://temp-4sem-apim.azure-api.net/",
+      "resourceId": "/subscriptions/[parameters('subscriptionId')]/resourceGroups/[parameters('resourceGroupName')]/providers/Microsoft.ApiManagement/service/temp-4sem-apim/apis/CoachingAPI",
+      "type": "apis.azure"
+    },
     "mssql1": {
-      "ignored": "true",
-      "type": "mssql"
+      "serviceConnectorResourceId": "/subscriptions/[parameters('subscriptionId')]/resourceGroups/[parameters('resourceGroupName')]/providers/Microsoft.Web/sites/temp-4sem-appservice/providers/Microsoft.ServiceLinker/linkers/AZURE_SQL_CONNECTIONSTRING_76355BA40F",
+      "secretStore": "AzureAppSettings",
+      "resourceId": "/subscriptions/[parameters('subscriptionId')]/resourceGroups/[parameters('resourceGroupName')]/providers/Microsoft.Sql/servers/temp-4sem-sqlserver/databases/temp-4sem-sqldb",
+      "type": "mssql.azure",
+      "connectionId": "AZURE_SQL_CONNECTIONSTRING"
     }
   }
 }

--- a/CoachingAPI/appsettings.Development.json
+++ b/CoachingAPI/appsettings.Development.json
@@ -1,8 +1,0 @@
-{
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    }
-  }
-}

--- a/CoachingAPI/appsettings.Development.json
+++ b/CoachingAPI/appsettings.Development.json
@@ -4,8 +4,5 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
-  },
-  "ConnectionStrings": {
-    //"AZURE_SQL_CONNECTIONSTRING": "<ConnectionString goes here for dev builds>"
   }
 }


### PR DESCRIPTION
Standardized the way the connection string is fetched.
Now the connection string is fetched directly from the `secrets.json` file, the same way it is fetched from a connection string equivalent environment variable in Azure. This removes the need for multiple ways to fetch what is essentially the same value.