### PR TITLE
API expansion

### DIFF
--- a/CoachingAPI/CoachingAPI.csproj
+++ b/CoachingAPI/CoachingAPI.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components.QuickGrid.EntityFrameworkAdapter" Version="8.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.4">
       <PrivateAssets>all</PrivateAssets>
@@ -18,6 +19,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 

--- a/CoachingAPI/Controllers/MatchesController.cs
+++ b/CoachingAPI/Controllers/MatchesController.cs
@@ -92,7 +92,7 @@ namespace CoachingAPI.Controllers
             {
                 await _context.SaveChangesAsync();
             }
-            // If the match was deleted after we retrieved them from the DB, return a 404
+            // If the match was deleted after we retrieved it from the DB, return a 404
             catch (DbUpdateConcurrencyException) when (!MatchExists(id))
             {
                 return NotFound();
@@ -151,6 +151,9 @@ namespace CoachingAPI.Controllers
         [HttpDelete("{id}")]
         public async Task<IActionResult> DeleteMatch(int id)
         {
+            if (_context.Matches == null)
+                return NotFound();
+
             var match = await _context.Matches.FindAsync(id);
 
             if (match == null)

--- a/CoachingAPI/Controllers/MatchesController.cs
+++ b/CoachingAPI/Controllers/MatchesController.cs
@@ -1,0 +1,176 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using CoachingAPI.Data;
+using CoachingAPI.Models;
+using CoachingAPI.Models.DTOs;
+using CoachingAPI.Models.Statistics;
+
+namespace CoachingAPI.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class MatchesController(PlayersDbContext context) : ControllerBase
+    {
+        private readonly PlayersDbContext _context = context;
+
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<Match>>> GetMatches()
+        {
+            if (_context.Matches == null)
+                return NotFound();
+
+            return await _context.Matches
+                .Include(m => m.Map)
+                .Include(m => m.Teams)
+                .ThenInclude(t => t.Memberships)
+                .ToListAsync();
+        }
+
+        [HttpGet("{id}")]
+        public async Task<ActionResult<Match>> GetMatch(int id)
+        {
+            if (_context.Matches == null)
+                return NotFound();
+
+            Match? match = await _context.Matches.FindAsync(id);
+
+            if (match == null)
+                return NotFound();
+            
+            // Explicitly load related entities
+            _context.Entry(match)
+                .Reference(m => m.Map)
+                .Load();
+
+            _context.Entry(match)
+                .Collection(m => m.Teams)
+                .Load();
+
+            foreach (Team team in match.Teams)
+            {
+                _context.Entry(team)
+                    .Collection(t => t.Memberships)
+                    .Load();
+            }
+
+            return match;
+        }
+
+        // To protect from overposting attacks, see https://go.microsoft.com/fwlink/?linkid=2123754
+        [HttpPut("{id}")]
+        public async Task<IActionResult> PutMatch(int id, MatchDTO matchDto)
+        {
+            Match? match = await _context.Matches.FindAsync(id);
+
+            if (match == null)
+                return NotFound();
+
+            // Remove the match from the teams that are currently associated with it
+            _context.Entry(match).Collection(m => m.Teams).Load();
+
+            foreach (Team team in match.Teams)
+                team.Matches.Remove(match);
+
+            // Update the match
+            match.Date = matchDto.Date;
+            match.MatchPlatform = matchDto.MatchPlatform;
+            match.MapName = matchDto.MapName;
+            match.WinnerTeamId = matchDto.WinnerTeamId;
+
+            match.Teams.Clear();
+            foreach (int teamId in matchDto.TeamIds)
+            {
+                Team? team = await _context.Teams.FindAsync(teamId);
+
+                if (team == null)
+                    return NotFound();
+
+                match.Teams.Add(team);
+            }
+
+            // Attempt to update the DB
+            try
+            {
+                await _context.SaveChangesAsync();
+            }
+            // If the match was deleted after we retrieved them from the DB, return a 404
+            catch (DbUpdateConcurrencyException) when (!MatchExists(id))
+            {
+                return NotFound();
+            }
+
+            return NoContent();
+        }
+
+        // To protect from overposting attacks, see https://go.microsoft.com/fwlink/?linkid=2123754
+        [HttpPost]
+        public async Task<ActionResult<Match>> PostMatch(MatchDTO matchDto)
+        {
+            // Get the map
+            Map? map = _context.Maps.Find(matchDto.MapName);
+
+            if (map == null)
+                return BadRequest($"No Map exists with MapName = {matchDto.MapName}");
+
+            // Get the winning team
+            Team? winningTeam = _context.Teams.Find(matchDto.WinnerTeamId);
+
+            if (winningTeam == null)
+                return BadRequest($"No Team exists with Id = {matchDto.WinnerTeamId}.");
+
+            // Get participating teams
+            List<Team> teams = [];
+
+            foreach (int teamId in matchDto.TeamIds)
+            {
+                Team? team = await _context.Teams.FindAsync(teamId);
+
+                if (team == null)
+                    return BadRequest($"No Team exists with Id = {teamId}.");
+
+                teams.Add(team);
+            }
+
+            // Create the new match
+            Match match = new()
+            {
+                Date = matchDto.Date,
+                MatchPlatform = matchDto.MatchPlatform,
+                MapName = matchDto.MapName,
+                WinnerTeamId = matchDto.WinnerTeamId,
+                Map = map,
+                Winner = winningTeam,
+                Teams = teams
+            };
+
+            _context.Matches.Add(match);
+            await _context.SaveChangesAsync();
+
+            return CreatedAtAction(nameof(GetMatch), new { id = match.Id }, match);
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> DeleteMatch(int id)
+        {
+            var match = await _context.Matches.FindAsync(id);
+
+            if (match == null)
+                return NotFound();            
+
+            _context.Matches.Remove(match);
+            await _context.SaveChangesAsync();
+
+            return NoContent();
+        }
+
+        /// <summary>
+        /// Determines if a <see cref="Match"/> with a matching ID exists.
+        /// </summary>
+        /// <param name="id">The ID of the match to look for.</param>
+        /// <returns>
+        /// <see langword="true"/> if a <see cref="Match"/> with a matching ID exists.<br/>
+        /// <see langword="false"/> otherwise.
+        /// </returns>
+        private bool MatchExists(int id) => _context.Matches.Any(e => e.Id == id);
+    }
+}

--- a/CoachingAPI/Controllers/MatchesController.cs
+++ b/CoachingAPI/Controllers/MatchesController.cs
@@ -3,7 +3,6 @@ using Microsoft.EntityFrameworkCore;
 using CoachingAPI.Data;
 using CoachingAPI.Models;
 using CoachingAPI.Models.DTOs;
-using CoachingAPI.Models.Statistics;
 
 namespace CoachingAPI.Controllers
 {

--- a/CoachingAPI/Controllers/PlayersController.cs
+++ b/CoachingAPI/Controllers/PlayersController.cs
@@ -41,7 +41,9 @@ namespace CoachingAPI.Controllers
             if (_context.Players == null)
                 return NotFound();
 
-            return await _context.Players.Include(p => p.Memberships).ToListAsync();
+            return await _context.Players
+                .Include(p => p.Memberships)
+                .ToListAsync();
         }
 
         [HttpGet("detailed/{id}")]

--- a/CoachingAPI/Controllers/PlayersController.cs
+++ b/CoachingAPI/Controllers/PlayersController.cs
@@ -1,5 +1,6 @@
 ﻿using CoachingAPI.Data;
 using CoachingAPI.Models;
+using CoachingAPI.Models.DTOs;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
@@ -7,132 +8,118 @@ namespace CoachingAPI.Controllers
 {
     [Route("api/[controller]")]
     [ApiController]
-    public class PlayersController : ControllerBase
+    public class PlayersController(PlayersDbContext context) : ControllerBase
     {
-        private readonly PlayersDbContext _context;
+        private readonly PlayersDbContext _context = context;
 
-        public PlayersController(PlayersDbContext context)
-        {
-            _context = context;
-            
-        }
-
-        // GET: api/Players
         [HttpGet]
         public async Task<ActionResult<IEnumerable<Player>>> GetPlayers()
         {
             if (_context.Players == null)
-            {
                 return NotFound();
-            }
 
             return await _context.Players.ToListAsync();
         }
 
-        // GET: api/Players/5
         [HttpGet("{id}")]
-        public async Task<ActionResult<Player>> GetPlayer(Guid id)
+        public async Task<ActionResult<Player>> GetPlayer(int id)
         {
             if (_context.Players == null)
-            {
                 return NotFound();
-            }
-            var player = await _context.Players.FindAsync(id);
+
+            Player? player = await _context.Players.FindAsync(id);
 
             if (player == null)
-            {
                 return NotFound();
-            }
 
             return player;
-        }   
+        }
 
-        // PUT: api/Players/5
+        [HttpGet("detailed")]
+        public async Task<ActionResult<IEnumerable<Player>>> GetPlayerDetailed()
+        {
+            if (_context.Players == null)
+                return NotFound();
+
+            return await _context.Players.Include(p => p.Memberships).ToListAsync();
+        }
+
+        [HttpGet("detailed/{id}")]
+        public async Task<ActionResult<Player>> GetPlayerDetailed(int id)
+        {
+            if (_context.Players == null)
+                return NotFound();
+
+            Player? player = await _context.Players.FindAsync(id);
+
+            if (player == null)
+                return NotFound();
+
+            _context.Entry(player)
+                .Collection(p => p.Memberships)
+                .Load();
+
+            return player;
+        }
+
         // To protect from overposting attacks, see https://go.microsoft.com/fwlink/?linkid=2123754
         [HttpPut("{id}")]
-        public async Task<IActionResult> PutPlayer(int id, Player player)
+        public async Task<IActionResult> PutPlayer(int id, PlayerDTO playerDto)
         {
-            if (id != player.Id)
-            {
-                return BadRequest();
-            }
+            Player? player = await _context.Players.FindAsync(id);
 
-            _context.Entry(player).State = EntityState.Modified;
+            if (player == null)
+                return NotFound();
 
+            player.Name = playerDto.Name;
+
+            // Attempt to update the DB
             try
             {
                 await _context.SaveChangesAsync();
             }
-            catch (DbUpdateConcurrencyException)
+            // If the player was deleted after we retrieved them from the DB, return a 404
+            catch (DbUpdateConcurrencyException) when (!PlayerExists(id))
             {
-                if (!PlayerExists(id))
-                {
-                    return NotFound();
-                }
-                else
-                {
-                    throw;
-                }
+                return NotFound();
             }
 
             return NoContent();
         }
 
-
-
-        // POST: api/Players
         // To protect from overposting attacks, see https://go.microsoft.com/fwlink/?linkid=2123754
         [HttpPost]
-        public async Task<ActionResult<Player>> PostPlayer(Player player)
+        public async Task<ActionResult<Player>> PostPlayer(PlayerDTO playerDto)
         {
-            if (_context.Players == null)
+            Player player = new()
             {
-                return Problem("Entity set 'PlayersDbContext.Players'  is null.");
-            }
+                Name = playerDto.Name
+            };
+
+            if (_context.Players == null)
+                return Problem("Entity set 'PlayersDbContext.Players' is null.");
+            
             _context.Players.Add(player);
             await _context.SaveChangesAsync();
 
-            return CreatedAtAction("GetPlayer", new { id = player.Id }, player);
+            return CreatedAtAction(nameof(GetPlayer), new { id = player.Id }, player);
         }
 
-        //POST: apy/Players/match/
-        [HttpPost("Matchpost")]
-        public async Task<ActionResult> PostMatch(DateTime date, MatchPlatform matchPlatform, MapName map, int fK_WinnerTeamId, List<int> teams, int winner)
-        {
-            Team winnerteam = await _context.Teams.FindAsync(winner);
-            List<Team> matchteams = _context.Teams.Where(t => teams.Contains(t.Id)).ToList();
-            Map mapused = _context.Maps.Find(map);
-            //_context.Add(new Match(date, matchPlatform,mapused,fK_WinnerTeamId,matchteams));
-            _context.SaveChanges();
-            return Ok();
-
-        }
-
-
-
-        // DELETE: api/Players/5
         [HttpDelete("{id}")]
-        public async Task<IActionResult> DeletePlayer(Guid id)
+        public async Task<IActionResult> DeletePlayer(int id)
         {
             if (_context.Players == null)
-            {
                 return NotFound();
-            }
-            var player = await _context.Players.FindAsync(id);
+            
+            Player? player = await _context.Players.FindAsync(id);
+            
             if (player == null)
-            {
                 return NotFound();
-            }
 
             _context.Players.Remove(player);
             await _context.SaveChangesAsync();
 
             return NoContent();
-        }
-
-        private bool PlayerExists(int id)
-        {
-            return (_context.Players?.Any(e => e.Id == id)).GetValueOrDefault();
         }
 
         [HttpGet("generate")]
@@ -146,7 +133,17 @@ namespace CoachingAPI.Controllers
             _context.Players.Add(player);
             await _context.SaveChangesAsync();
 
-            return CreatedAtAction("GetPlayer", new { id = player.Id }, player);
+            return CreatedAtAction(nameof(GetPlayer), new { id = player.Id }, player);
         }
+
+        /// <summary>
+        /// Determines if a <see cref="Player"/> with a matching ID exists.
+        /// </summary>
+        /// <param name="id">The ID of the player to look for.</param>
+        /// <returns>
+        /// <see langword="true"/> if a <see cref="Player"/> with a matching ID exists.<br/>
+        /// <see langword="false"/> otherwise.
+        /// </returns>
+        private bool PlayerExists(int id) => _context.Players.Any(e => e.Id == id);
     }
 }

--- a/CoachingAPI/Controllers/PlayersController.cs
+++ b/CoachingAPI/Controllers/PlayersController.cs
@@ -1,8 +1,8 @@
-﻿using CoachingAPI.Data;
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using CoachingAPI.Data;
 using CoachingAPI.Models;
 using CoachingAPI.Models.DTOs;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 
 namespace CoachingAPI.Controllers
 {

--- a/CoachingAPI/Controllers/TeamsController.cs
+++ b/CoachingAPI/Controllers/TeamsController.cs
@@ -1,0 +1,115 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using CoachingAPI.Data;
+using CoachingAPI.Models;
+using CoachingAPI.Models.DTOs;
+
+namespace CoachingAPI.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class TeamsController(PlayersDbContext context) : ControllerBase
+    {
+        private readonly PlayersDbContext _context = context;
+
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<Team>>> GetTeams()
+        {
+            if (_context.Teams == null)
+                return NotFound();
+
+            return await _context.Teams.Include(t => t.Memberships).ToListAsync();
+        }
+
+        [HttpGet("{id}")]
+        public async Task<ActionResult<Team>> GetTeam(int id)
+        {
+            if (_context.Teams == null)
+                return NotFound();
+
+            Team? team = await _context.Teams.FindAsync(id);
+
+            if (team == null)
+                return NotFound();
+
+            _context.Entry(team)
+                .Collection(t => t.Memberships)
+                .Load();
+
+            return team;
+        }
+
+        // To protect from overposting attacks, see https://go.microsoft.com/fwlink/?linkid=2123754
+        [HttpPut("{id}")]
+        public async Task<IActionResult> PutTeam(int id, TeamDTO teamDto)
+        {
+            if (_context.Teams == null)
+                return NotFound();
+
+            Team? team = await _context.Teams.FindAsync(id);
+
+            if (team == null)
+                return BadRequest($"No Team exists with id = {id}.");
+
+            // Update the team
+            team.Name = teamDto.Name;
+            team.IsMatchMaking = teamDto.IsMatchMaking;
+
+            // Attempt to update the DB
+            try
+            {
+                await _context.SaveChangesAsync();
+            }
+            // If the team was deleted after we retrieved it from the DB, return a 404
+            catch (DbUpdateConcurrencyException) when (!TeamExists(id))
+            {
+                return NotFound();
+            }
+
+            return NoContent();
+        }
+
+        // To protect from overposting attacks, see https://go.microsoft.com/fwlink/?linkid=2123754
+        [HttpPost]
+        public async Task<ActionResult<Team>> PostTeam(TeamDTO teamDto)
+        {
+            Team team = new()
+            {
+                Name = teamDto.Name,
+                IsMatchMaking = teamDto.IsMatchMaking
+            };
+
+            _context.Teams.Add(team);
+            await _context.SaveChangesAsync();
+
+            return CreatedAtAction(nameof(GetTeam), new { id = team.Id }, team);
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> DeleteTeam(int id)
+        {
+            if (_context.Teams == null)
+                return NotFound();
+
+            Team? team = await _context.Teams.FindAsync(id);
+
+            if (team == null)
+                return NotFound();
+
+            _context.Teams.Remove(team);
+            await _context.SaveChangesAsync();
+
+            return NoContent();
+        }
+
+        /// <summary>
+        /// Determines if a <see cref="Team"/> with a matching ID exists.
+        /// </summary>
+        /// <param name="id">The ID of the team to look for.</param>
+        /// <returns>
+        /// <see langword="true"/> if a <see cref="Team"/> with a matching ID exists.<br/>
+        /// <see langword="false"/> otherwise.
+        /// </returns>
+        private bool TeamExists(int id) => _context.Teams.Any(e => e.Id == id);
+    }
+}

--- a/CoachingAPI/Data/PlayersDbContext.cs
+++ b/CoachingAPI/Data/PlayersDbContext.cs
@@ -70,9 +70,9 @@ namespace CoachingAPI.Data
                 .IsUnique();
 
             // Define many-to-many relationship between Match and Team
-            //modelBuilder.Entity<Match>()
-            //    .HasMany(m => m.Teams) // Match has many relationships to Team, via Teams property
-            //    .WithMany(t => t.Matches); // Team has many relationships to Match, via Matches property
+            modelBuilder.Entity<Match>()
+                .HasMany(m => m.Teams) // Match has many relationships to Team, via Teams property
+                .WithMany(t => t.Matches); // Team has many relationships to Match, via Matches property
 
             // Define one-to-many relationship between Team and Match.Winner
             modelBuilder.Entity<Match>()

--- a/CoachingAPI/Data/PlayersDbContext.cs
+++ b/CoachingAPI/Data/PlayersDbContext.cs
@@ -24,6 +24,7 @@ namespace CoachingAPI.Data
             modelBuilder.Entity<Match>().ToTable("Match");
             modelBuilder.Entity<Map>().ToTable("Map");
 
+            // We keep these tables plural, because of the "stats" suffix
             modelBuilder.Entity<PlayerMatchStats>().ToTable("PlayerMatchStats");
             modelBuilder.Entity<TeamMatchStats>().ToTable("TeamMatchStats");
 

--- a/CoachingAPI/Data/PlayersDbContext.cs
+++ b/CoachingAPI/Data/PlayersDbContext.cs
@@ -70,9 +70,9 @@ namespace CoachingAPI.Data
                 .IsUnique();
 
             // Define many-to-many relationship between Match and Team
-            modelBuilder.Entity<Match>()
-                .HasMany(m => m.Teams) // Match has many relationships to Team, via Teams property
-                .WithMany(t => t.Matches); // Team has many relationships to Match, via Matches property
+            //modelBuilder.Entity<Match>()
+            //    .HasMany(m => m.Teams) // Match has many relationships to Team, via Teams property
+            //    .WithMany(t => t.Matches); // Team has many relationships to Match, via Matches property
 
             // Define one-to-many relationship between Team and Match.Winner
             modelBuilder.Entity<Match>()

--- a/CoachingAPI/Data/PlayersDbContext.cs
+++ b/CoachingAPI/Data/PlayersDbContext.cs
@@ -1,4 +1,5 @@
 ﻿using CoachingAPI.Models;
+using CoachingAPI.Models.Statistics;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Hosting;
@@ -41,11 +42,11 @@ namespace CoachingAPI.Data
                 .HasKey(tms => new { tms.PlayerId, tms.MatchId });
 
             // Define foreign key for TeamMatchStats property in PlayerMatchStats
-            modelBuilder.Entity<PlayerMatchStats>()
-                .HasOne(pms => pms.TeamMatchStats)
-                .WithMany()
-                .HasForeignKey(pms => new { pms.TeamId, pms.MatchId })
-                .OnDelete(DeleteBehavior.NoAction); // Keep the team match stats when a player's match stats is deleted
+            //modelBuilder.Entity<PlayerMatchStats>()
+            //    .HasOne(pms => pms.TeamMatchStats)
+            //    .WithMany()
+            //    .HasForeignKey(pms => new { pms.TeamId, pms.MatchId })
+            //    .OnDelete(DeleteBehavior.NoAction); // Keep the team match stats when a player's match stats is deleted
 
             // Configure indexing for PlayerMatchStats
             modelBuilder.Entity<PlayerMatchStats>()
@@ -80,15 +81,15 @@ namespace CoachingAPI.Data
                 .HasForeignKey(m => m.WinnerTeamId) // Specifies the foreign key property in Match
                 .OnDelete(DeleteBehavior.NoAction); // Prevents deletion of a the winning team on match deletion
 
-            modelBuilder.Entity<Match>()
-                .HasMany(m => m.PlayerMatchStats)
-                .WithOne(pps => pps.Match)
-                .OnDelete(DeleteBehavior.Cascade); // Ensure that when a match is deleted, the associated PlayerMatchStats are also deleted
+            //modelBuilder.Entity<Match>()
+            //    .HasMany(m => m.PlayerMatchStats)
+            //    .WithOne(pps => pps.Match)
+            //    .OnDelete(DeleteBehavior.Cascade); // Ensure that when a match is deleted, the associated PlayerMatchStats are also deleted
 
-            modelBuilder.Entity<Match>()
-                .HasOne(m => m.TeamMatchStats)
-                .WithOne(tps => tps.Match)
-                .OnDelete(DeleteBehavior.Cascade); // Ensure that when a match is deleted, the associated TeamMatchStats are also deleted
+            //modelBuilder.Entity<Match>()
+            //    .HasOne(m => m.TeamMatchStats)
+            //    .WithOne(tps => tps.Match)
+            //    .OnDelete(DeleteBehavior.Cascade); // Ensure that when a match is deleted, the associated TeamMatchStats are also deleted
 
             base.OnModelCreating(modelBuilder);
         }

--- a/CoachingAPI/Migrations/20240424072425_ExcludeStatsClasses.Designer.cs
+++ b/CoachingAPI/Migrations/20240424072425_ExcludeStatsClasses.Designer.cs
@@ -4,6 +4,7 @@ using CoachingAPI.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CoachingAPI.Migrations
 {
     [DbContext(typeof(PlayersDbContext))]
-    partial class PlayersDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240424072425_ExcludeStatsClasses")]
+    partial class ExcludeStatsClasses
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/CoachingAPI/Migrations/20240424072425_ExcludeStatsClasses.cs
+++ b/CoachingAPI/Migrations/20240424072425_ExcludeStatsClasses.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CoachingAPI.Migrations
+{
+    /// <inheritdoc />
+    public partial class ExcludeStatsClasses : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_PlayerMatchStats_TeamMatchStats_TeamId_MatchId",
+                table: "PlayerMatchStats");
+
+            migrationBuilder.DropIndex(
+                name: "IX_PlayerMatchStats_TeamId_MatchId",
+                table: "PlayerMatchStats");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_PlayerMatchStats_TeamId_MatchId",
+                table: "PlayerMatchStats",
+                columns: new[] { "TeamId", "MatchId" });
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_PlayerMatchStats_TeamMatchStats_TeamId_MatchId",
+                table: "PlayerMatchStats",
+                columns: new[] { "TeamId", "MatchId" },
+                principalTable: "TeamMatchStats",
+                principalColumns: new[] { "TeamId", "MatchId" });
+        }
+    }
+}

--- a/CoachingAPI/Migrations/PlayersDbContextModelSnapshot.cs
+++ b/CoachingAPI/Migrations/PlayersDbContextModelSnapshot.cs
@@ -212,7 +212,7 @@ namespace CoachingAPI.Migrations
 
                     b.HasIndex("TeamsId");
 
-                    b.ToTable("MatchTeam");
+                    b.ToTable("MatchTeam", (string)null);
                 });
 
             modelBuilder.Entity("CoachingAPI.Models.Match", b =>

--- a/CoachingAPI/Models/DTOs/GeneralStatsDTO.cs
+++ b/CoachingAPI/Models/DTOs/GeneralStatsDTO.cs
@@ -1,8 +1,8 @@
 ﻿using CoachingAPI.Models.Interfaces;
 
-namespace CoachingAPI.Models
+namespace CoachingAPI.Models.DTOs
 {
-    public class DTOGeneralStats(ITrackable target, List<DTOMapStats> mapStats)
+    public class GeneralStatsDTO(ITrackable target, List<MapStatsDTO> mapStats)
     {
         public int Wins { get; set; }
         public int Losses { get; set; }
@@ -14,6 +14,6 @@ namespace CoachingAPI.Models
         public int Headshots { get; set; }
 
         public ITrackable Target { get; set; } = target;
-        public List<DTOMapStats> MapStats { get; set; } = mapStats;
+        public List<MapStatsDTO> MapStats { get; set; } = mapStats;
     }
 }

--- a/CoachingAPI/Models/DTOs/MapStatsDTO.cs
+++ b/CoachingAPI/Models/DTOs/MapStatsDTO.cs
@@ -1,8 +1,8 @@
 ﻿using System.ComponentModel.DataAnnotations.Schema;
 
-namespace CoachingAPI.Models
+namespace CoachingAPI.Models.DTOs
 {
-    public class DTOMapStats(Map map)
+    public class MapStatsDTO(Map map)
     {
         public int MatchesPlayed { get; set; }
         public int Wins { get; set; }

--- a/CoachingAPI/Models/DTOs/MatchDTO.cs
+++ b/CoachingAPI/Models/DTOs/MatchDTO.cs
@@ -1,0 +1,13 @@
+﻿namespace CoachingAPI.Models.DTOs
+{
+    public class MatchDTO(DateTime date, MatchPlatform matchPlatform, MapName mapName, int winnerTeamId, List<int> teamIds)
+    {
+        public DateTime Date { get; set; } = date;
+        public MatchPlatform MatchPlatform { get; set; } = matchPlatform;
+
+        // Foreign keys
+        public MapName MapName { get; set; } = mapName;
+        public int WinnerTeamId { get; set; } = winnerTeamId;
+        public List<int> TeamIds { get; set; } = teamIds;
+    }
+}

--- a/CoachingAPI/Models/DTOs/PlayerDTO.cs
+++ b/CoachingAPI/Models/DTOs/PlayerDTO.cs
@@ -1,0 +1,7 @@
+﻿namespace CoachingAPI.Models.DTOs
+{
+    public class PlayerDTO(string name)
+    {
+        public string Name { get; set; } = name;
+    }
+}

--- a/CoachingAPI/Models/DTOs/TeamDTO.cs
+++ b/CoachingAPI/Models/DTOs/TeamDTO.cs
@@ -1,0 +1,8 @@
+﻿namespace CoachingAPI.Models.DTOs
+{
+    public class TeamDTO(string name, bool isMatchMaking)
+    {
+        public string Name { get; set; } = name;
+        public bool IsMatchMaking { get; set; } = isMatchMaking;
+    }
+}

--- a/CoachingAPI/Models/Map.cs
+++ b/CoachingAPI/Models/Map.cs
@@ -21,5 +21,25 @@ namespace CoachingAPI.Models
         [Key]
         public MapName Name { get; set; }
         public bool Active { get; set; }
+
+        static public string GetDisplayName(MapName name)
+        {
+            string displayName = name switch
+            {
+                MapName.de_mirage => "Mirage",
+                MapName.de_vertigo => "Vertigo",
+                MapName.de_ancient => "Ancient",
+                MapName.de_dust2 => "Dust II",
+                MapName.de_train => "Train",
+                MapName.de_overpass => "Overpass",
+                MapName.de_nuke => "Nuke",
+                MapName.de_inferno => "Inferno",
+                MapName.de_anubis => "Anubis",
+                MapName.de_tuscan => "Tuscan",
+                _ => throw new ArgumentException("Invalid map name"),
+            };
+
+            return displayName;
+        }
     }
 }

--- a/CoachingAPI/Models/Match.cs
+++ b/CoachingAPI/Models/Match.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json.Serialization;
 
 namespace CoachingAPI.Models
 {
@@ -21,16 +22,18 @@ namespace CoachingAPI.Models
         public MatchPlatform MatchPlatform { get; set; }
 
         // Navigation properties
+        [JsonIgnore]
         public MapName MapName { get; set; }
         public int WinnerTeamId { get; set; }
 
         [ForeignKey(nameof(MapName))]
         public Map Map { get; set; }
+        [JsonIgnore] // Don't show the winner team object in the JSON response, only the ID
         [ForeignKey(nameof(WinnerTeamId))]
         public Team? Winner { get; set; }
 
         public List<Team> Teams { get; set; } = [];
-        public List<PlayerMatchStats>? PlayerMatchStats { get; set; }
-        public TeamMatchStats? TeamMatchStats { get; set; }
+        //public List<PlayerMatchStats>? PlayerMatchStats { get; set; }
+        //public List<TeamMatchStats>? TeamMatchStats { get; set; }
     }
 }

--- a/CoachingAPI/Models/Membership.cs
+++ b/CoachingAPI/Models/Membership.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json.Serialization;
 
 namespace CoachingAPI.Models
 {
@@ -20,8 +21,10 @@ namespace CoachingAPI.Models
         public int PlayerId { get; set; }
         public int TeamId { get; set; }
 
+        [JsonIgnore] // Use this to prevent circular reference when serializing to JSON
         [ForeignKey(nameof(PlayerId))]
         public Player Player { get; set; }
+        [JsonIgnore] // Use this to prevent circular reference when serializing to JSON
         [ForeignKey(nameof(TeamId))]
         public Team Team { get; set; }
     }

--- a/CoachingAPI/Models/Statistics/PlayerMatchStats.cs
+++ b/CoachingAPI/Models/Statistics/PlayerMatchStats.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations.Schema;
 
-namespace CoachingAPI.Models
+namespace CoachingAPI.Models.Statistics
 {
     public class PlayerMatchStats
     {
@@ -20,7 +20,5 @@ namespace CoachingAPI.Models
         public Player Player { get; set; }
         [ForeignKey(nameof(MatchId))]
         public Match Match { get; set; }
-
-        public TeamMatchStats TeamMatchStats { get; set; }
     }
 }

--- a/CoachingAPI/Models/Statistics/TeamMatchStats.cs
+++ b/CoachingAPI/Models/Statistics/TeamMatchStats.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations.Schema;
 
-namespace CoachingAPI.Models
+namespace CoachingAPI.Models.Statistics
 {
     public class TeamMatchStats
     {

--- a/CoachingAPI/Models/Team.cs
+++ b/CoachingAPI/Models/Team.cs
@@ -1,6 +1,7 @@
 ﻿using CoachingAPI.Models.Interfaces;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json.Serialization;
 
 namespace CoachingAPI.Models
 {
@@ -15,6 +16,7 @@ namespace CoachingAPI.Models
 
         // Navigation properties
         public List<Membership> Memberships { get; set; } = [];
+        [JsonIgnore] // Ignore this to avoid circular reference when serializing to JSON
         public List<Match> Matches { get; set; } = [];
     }
 }

--- a/CoachingAPI/Models/Team.cs
+++ b/CoachingAPI/Models/Team.cs
@@ -15,6 +15,6 @@ namespace CoachingAPI.Models
 
         // Navigation properties
         public List<Membership> Memberships { get; set; } = [];
-        public List<Match> Matches { get; set; } = [];
+        //public List<Match> Matches { get; set; } = [];
     }
 }

--- a/CoachingAPI/Models/Team.cs
+++ b/CoachingAPI/Models/Team.cs
@@ -16,7 +16,5 @@ namespace CoachingAPI.Models
         // Navigation properties
         public List<Membership> Memberships { get; set; } = [];
         public List<Match> Matches { get; set; } = [];
-       
-      
     }
 }

--- a/CoachingAPI/Models/Team.cs
+++ b/CoachingAPI/Models/Team.cs
@@ -15,6 +15,6 @@ namespace CoachingAPI.Models
 
         // Navigation properties
         public List<Membership> Memberships { get; set; } = [];
-        //public List<Match> Matches { get; set; } = [];
+        public List<Match> Matches { get; set; } = [];
     }
 }


### PR DESCRIPTION
I extended `PlayersController` by implementing REST API functionality for the `Player` class. I also added controller classes for each of the `Match` and the `Team` classes.

Note however, that the `Stats` classes have been decoupled form the base model classes, as they are no longer referenced by any base model classes. They are still accessible by quering them directly - we can add controller support for the `Stats` classes later if needed.